### PR TITLE
disable binary logging

### DIFF
--- a/config/user.cnf
+++ b/config/user.cnf
@@ -5,5 +5,5 @@ default-authentication-plugin=mysql_native_password
 # Listen on all interfaces
 bind-address=0.0.0.0
 
-# Purge logs
-expire_logs_days=7
+# Disable binary logging
+binlog_expire_logs_seconds=0


### PR DESCRIPTION
## Summary

Logs are expanding way too quickly. Disable for now and rely on periodic backups instead.