### PR TITLE
set proper bin log off flag

### DIFF
--- a/config/user.cnf
+++ b/config/user.cnf
@@ -6,4 +6,4 @@ default-authentication-plugin=mysql_native_password
 bind-address=0.0.0.0
 
 # Disable binary logging
-binlog_expire_logs_seconds=0
+log_bin=OFF


### PR DESCRIPTION
## Summary

- This should be the correct flag to disable mysql logging 

## Notes

- Delete existing logs by running `PURGE BINARY LOGS BEFORE '2021-09-10 22:46:26';` when logged in as "admin" or "root"
- To check the flag and related flags you can log into the database using the read_only user credentials in 1Password and run `SHOW VARIABLES LIKE '%bin%';` to and check whether `log_bin` is set to off
- We should  follow [this advice](https://serverfault.com/questions/366924/mysql-check-enable-binary-logs#comment372566_366931) to have logs go to a separate disk partition to avoid issues in the future

@devangt @gvocale @Otterwerks @APiligrim @jpham1109 
