### PR TITLE
disable bin log with command line flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,3 +3,4 @@
 FROM mysql/mysql-server:8.0.24
 
 COPY config/user.cnf /etc/mysql/my.cnf
+CMD [ "--disable-log-bin" ]


### PR DESCRIPTION
## Summary

- Binary log refuses to die... this time boot up mysql with with command line flag to disable

Docs: https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#option_mysqld_log-bin