### PR TITLE
upgrade to 8.0.28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # You can change this to a newer version of MySQL available at
 # https://hub.docker.com/r/mysql/mysql-server/tags/
-FROM mysql/mysql-server:8.0.24
+FROM mysql/mysql-server:8.0.28
 
 COPY config/user.cnf /etc/mysql/my.cnf
 CMD [ "--disable-log-bin" ]


### PR DESCRIPTION
## Summary

Upgrade to 8.0.28 to potentially fix issue with mysql server [using all available physical memory](https://github.com/docker-library/mysql/issues/579#issuecomment-1018216782) on the machine.