### PR TITLE
increase innodb buffer pool settings

### DIFF
--- a/config/user.cnf
+++ b/config/user.cnf
@@ -7,3 +7,13 @@ bind-address=0.0.0.0
 
 # Disable binary logging
 log_bin=OFF
+
+# Increase buffer pool chunk size to 0.25GB
+innodb_buffer_pool_chunk_size=268435456
+
+# Set number of buffer pool instances
+innodb_buffer_pool_instances=10
+
+# Increase buffer pool size to 2.5GB
+# Must be a multiple of chunk_size * pool_instances
+innodb_buffer_pool_size=2684354560


### PR DESCRIPTION
## Summary

The default cache size for our mysql image is 0.125GB with a single cache instance. Best practices recommend using up to 70 or 80% of available memory for caching and setting a generous per-cache size. 

This incremental update doubles the size of the cache instances to 0.25GB and adds 9 more for a total of 10 caches and 2.5GB of memory usage out of 4GB available on the machine. This should be fairly conservative and allow plenty of room for other database and system processes. 

See:
https://dev.mysql.com/doc/refman/5.7/en/innodb-buffer-pool-resize.html
https://www.percona.com/blog/2016/05/03/best-practices-for-configuring-optimal-mysql-memory-usage/
https://www.percona.com/blog/2016/10/12/mysql-5-7-performance-tuning-immediately-after-installation/
